### PR TITLE
generic rollup interface

### DIFF
--- a/contracts/handlers/ERC1155Handler.sol
+++ b/contracts/handlers/ERC1155Handler.sol
@@ -30,7 +30,7 @@ contract ERC1155Handler is IDepositExecute, HandlerHelpers, ERC1155Safe, ERC1155
         @param depositer Address of account making the deposit in the Bridge contract.
         @param data Consists of ABI-encoded arrays of tokenIDs and amounts.
      */
-    function deposit(bytes32 resourceID, address depositer, bytes calldata data) external override onlyBridge returns (bytes memory metaData) {
+    function deposit(bytes32 resourceID, address depositer, bytes calldata data) external override onlyBridge returns (bytes memory) {
         uint[] memory tokenIDs;
         uint[] memory amounts;
 

--- a/contracts/handlers/RollupHandler.sol
+++ b/contracts/handlers/RollupHandler.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IDepositExecute.sol";
+import "../interfaces/IRollup.sol";
+import "./HandlerHelpers.sol";
+
+contract RollupHandler is IDepositExecute, HandlerHelpers, IRollup {
+    constructor(address bridgeAddress) public HandlerHelpers(bridgeAddress) {}
+
+    mapping(uint72 => Metadata) _rollupInfos;
+
+    function deposit(
+        bytes32,
+        address,
+        bytes calldata
+    ) external override onlyBridge returns (bytes memory) {
+        require(false, "deposit not supported in RollupHandler");
+    }
+
+    function rollup(bytes32, bytes calldata) external override onlyBridge {
+        require(false, "rollup not supported in RollupHandler");
+    }
+
+    struct Metadata {
+        uint8 domainID;
+        bytes32 resourceID;
+        uint64 nonce;
+        bytes32 msgRootHash;
+        bytes32 stateRootHash;
+        uint256 batchSize;
+        uint256 totalSize;
+    }
+
+    /**
+        @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
+        @param data Consists of {resourceID}, {lenMetaData}, and {metaData}.
+        @notice Data passed into the function should be constructed as follows:
+        len(data)                              uint256     bytes  0  - 32
+        data                                   bytes       bytes  32 - END
+        @notice {contractAddress} is required to be whitelisted
+        @notice If {_contractAddressToExecuteFunctionSignature}[{contractAddress}] is set,
+        {metaData} is expected to consist of needed function arguments.
+     */
+    function executeProposal(bytes32 resourceID, bytes calldata data)
+        external
+        override
+        onlyBridge
+    {
+        address contractAddress = _resourceIDToTokenContractAddress[resourceID];
+        require(
+            _contractWhitelist[contractAddress],
+            "provided contractAddress is not whitelisted"
+        );
+
+        Metadata memory md = abi.decode(data, (Metadata));
+        uint72 nonceAndID = (uint72(md.nonce) << 8) | uint72(md.domainID);
+        _rollupInfos[nonceAndID] = md;
+    }
+
+    // https://github.com/binodnp/openzeppelin-solidity/blob/master/contracts/cryptography/MerkleProof.sol
+    function _verify(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash < proofElement) {
+                // Hash(current computed hash + current element of the proof)
+                computedHash = keccak256(
+                    abi.encodePacked(computedHash, proofElement)
+                );
+            } else {
+                // Hash(current element of the proof + current computed hash)
+                computedHash = keccak256(
+                    abi.encodePacked(proofElement, computedHash)
+                );
+            }
+        }
+
+        // Check if the computed hash (root) is equal to the provided root
+        return computedHash == root;
+    }
+
+    function verifyRollupMsg(
+        uint8 originDomainID,
+        bytes32 resourceID,
+        uint64 nonce,
+        bytes32 msgRootHash,
+        bytes32 leaf,
+        bytes32[] calldata _proof
+    ) external view onlyBridge returns (bool) {
+        uint72 nonceAndID = (uint72(nonce) << 8) | uint72(originDomainID);
+        Metadata memory md = _rollupInfos[nonceAndID];
+        require(md.msgRootHash == msgRootHash);
+        require(md.resourceID == resourceID);
+        uint256 proofLength = md.totalSize / md.batchSize;
+        if (md.totalSize % md.batchSize != 0) {
+            proofLength++;
+        }
+        require(proofLength == _proof.length, "invalid proof length");
+        require(_verify(_proof, md.stateRootHash, leaf), "invalid proof");
+        return true;
+    }
+}

--- a/contracts/interfaces/IRollupSender.sol
+++ b/contracts/interfaces/IRollupSender.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+/**
+    @title Interface for handler contracts that support deposits and deposit executions.
+    @author ChainSafe Systems.
+ */
+interface IRollupSender {
+    enum RollupMsgType {
+        SetKV
+    }
+
+    struct KvMsg {
+        bytes key;
+        bytes value;
+    }
+
+    struct RollupMessage {
+        RollupMsgType ty;
+        string tag;
+        bytes data;
+    }
+
+    enum RollupStateType {
+        Map
+    }
+
+    struct RollupState {
+        RollupStateType ty;
+        string tag;
+        bytes records;
+    }
+
+    function sendRollupMsg(
+        bytes32 resourceID,
+        RollupMessage[] calldata messages
+    ) external;
+
+    function executeRollupMsgOn(
+        uint8 destDomainID,
+        bytes32 resourceID,
+        uint64 batchSize
+    ) external;
+
+    function verifyRollupMsg(
+        uint8 originDomainID,
+        bytes32 resourceID,
+        uint64 nonce,
+        bytes32 msgRootHash,
+        int256 batchIdx,
+        bytes calldata states,
+        bytes32[] calldata _proof
+    ) external returns (bool);
+}

--- a/contracts/utils/BaseRollupBridge.sol
+++ b/contracts/utils/BaseRollupBridge.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IRollupSender.sol";
+
+contract BaseRollupBridge {
+    event SendMsg(bytes32 resourceID, IRollupSender.RollupMessage[] messages, bytes32 proof);
+    event Rollup(
+        uint8 destDomainID,
+        bytes32 resourceID,
+        uint64 nonce,
+        uint64 batchSize,
+        bytes32 proof
+    );
+
+    mapping(bytes32 => bytes32) _latestState;
+
+    function _sendRollupMsg(bytes32 resourceID, IRollupSender.RollupMessage[] calldata messages)
+        internal
+    {
+        bytes32 proof = _latestState[resourceID];
+        for (uint256 i = 0; i < messages.length; i++) {
+            proof = keccak256(abi.encode(proof, messages[i]));
+        }
+        _latestState[resourceID] = proof;
+        emit SendMsg(resourceID, messages, proof);
+    }
+
+    function _executeRollupMsgOn(
+        uint8 destDomainID,
+        bytes32 resourceID,
+        uint64 nonce,
+        uint64 batchSize
+    ) internal {
+        bytes32 finalProof = _latestState[resourceID];
+        if (finalProof == 0) {
+            return;
+        }
+        _latestState[resourceID] = 0;
+        emit Rollup(destDomainID, resourceID, nonce, batchSize, finalProof);
+    }
+}

--- a/contracts/utils/RollupSDK.sol
+++ b/contracts/utils/RollupSDK.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IRollupReceiver.sol";
+import "../interfaces/IRollupSender.sol";
+
+contract RollupSDK {
+    address public immutable _bridgeAddress;
+    bytes32 public immutable _resourceID;
+    mapping(uint72 => bool) _rollupStates;
+
+    constructor(
+        address bridgeAddress,
+        bytes32 resourceID
+    ) public {
+        _bridgeAddress = bridgeAddress;
+        _resourceID = resourceID;
+    }
+
+    function executeRollup(
+        uint8 originDomainID,
+        bytes32 resourceID,
+        uint64 nonce,
+        bytes32 msgRootHash,
+        int256 batchIdx,
+        bytes calldata states,
+        bytes32[] calldata _proof
+    ) external {
+        require(
+            IRollupSender(_bridgeAddress).verifyRollupMsg(
+                originDomainID,
+                resourceID,
+                nonce,
+                msgRootHash,
+                batchIdx,
+                states,
+                _proof
+            ),
+            "verify fail"
+        );
+        IRollupSender.RollupState[] memory rollupStates;
+        rollupStates = abi.decode(states, (IRollupSender.RollupState[]));
+        onExecuteRollupMsg(rollupStates);
+    }
+
+    function onExecuteRollupMsg(IRollupSender.RollupState[] memory) public pure virtual {
+        require(false, "onExecuteRollupMsg is not implemented");
+    }
+
+    function sendRollupMsg(IRollupSender.RollupMessage[] calldata messages) internal {
+        IRollupSender(_bridgeAddress).sendRollupMsg(_resourceID, messages);
+    }
+
+    function executeRollupMsgOn(uint8 destDomainID, uint64 batchSize) internal {
+        IRollupSender(_bridgeAddress).executeRollupMsgOn(
+            destDomainID,
+            _resourceID,
+            batchSize
+        );
+    }
+}


### PR DESCRIPTION
1. Developer Contract should integrate RollupSDK.sol

send message or trigger execute:
L2 Developer Contract(RollupSDK) -> BridgeContract(sendRollupMsg, executeRollupMsgOn)

relayer:
BridgeContract(voteProposal,executeProposal)

execute:
L1 Developer Contract(RollupSDK) -> BridgeContract(verify)